### PR TITLE
build -> built

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pointer [![GoDoc](https://godoc.org/github.com/AlekSi/pointer?status.svg)](https://godoc.org/github.com/AlekSi/pointer) [![Build Status](https://travis-ci.org/AlekSi/pointer.svg)](https://travis-ci.org/AlekSi/pointer)
 
-Go package pointer provides helpers to get pointers to values of build-in types.
+Go package pointer provides helpers to get pointers to values of built-in types.
 
 ```
 go get github.com/AlekSi/pointer


### PR DESCRIPTION
The same typo is in the github project description:

![screenshot from 2018-06-22 12-05-22](https://user-images.githubusercontent.com/2706882/41786842-933de6ce-7614-11e8-8d68-5ddf3c8fcb0b.png)
