### PR TITLE
 Add poweron architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 sudo: false
-
+arch:
+  - ppc64le
+  - amd64
 go:
   - 1.x
   - master


### PR DESCRIPTION
Please review and merge the changes ,This is part of the Ubuntu distribution for ppc64le.
This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.