### PR TITLE
add Deref() and GetValue() funcs

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -34,3 +34,54 @@ func Get[T any](t *T) T {
 	}
 	return *t
 }
+
+// Deref returns the value from the passed pointer, or nil, if the passed non-nil pointer have a nil value.
+func Deref[T any](t *T) any {
+	if t == (*T)(nil) {
+		return nil
+	}
+	return *t
+}
+
+// GetValue returns the value from the passed pointer, or nil, if the passed non-nil pointer have a nil value.
+// Only supports builtin primitive types.
+func GetValue(t any) any {
+	var x any
+	switch v := t.(type) {
+	case *bool:
+		x = Deref(v)
+	case *byte:
+		x = Deref(v)
+	case *complex64:
+		x = Deref(v)
+	case *complex128:
+		x = Deref(v)
+	case *float32:
+		x = Deref(v)
+	case *float64:
+		x = Deref(v)
+	case *int:
+		x = Deref(v)
+	case *int8:
+		x = Deref(v)
+	case *int16:
+		x = Deref(v)
+	case *int32:
+		x = Deref(v)
+	case *int64:
+		x = Deref(v)
+	case *string:
+		x = Deref(v)
+	case *uint16:
+		x = Deref(v)
+	case *uint32:
+		x = Deref(v)
+	case *uint64:
+		x = Deref(v)
+	case *uintptr:
+		x = Deref(v)
+	default:
+		x = v
+	}
+	return x
+}

--- a/generic_test.go
+++ b/generic_test.go
@@ -30,4 +30,13 @@ func TestGeneric(t *testing.T) {
 	if Get(&x) != x {
 		t.Errorf("Get(%v)", &x)
 	}
+	if Deref(&x) != x {
+		t.Errorf("Deref(%v)", &x)
+	}
+	if Deref((*time.Time)(nil)) != nil {
+		t.Errorf("Deref(%v)", nil)
+	}
+	if GetValue(To(x.Second())).(int) != 40 {
+		t.Errorf("GetValue(%v)", x.Second())
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/AlekSi/pointer
 
-go 1.18
+go 1.19


### PR DESCRIPTION
Signed-off-by: Furkan <furkan.turkal@trendyol.com>

I tried to use `pointer` package first time, but unfortunately it couldn't cover my needs for the generics in the first place. So, this PR introduces 2 new functions for generics:

* `Deref()`: Like `Get()` but slightly different. It returns `any`. Which we can nil-check.
* `GetValue()`: Like the functions in `value.go`, but using generics to _deref_ under the hood. Only supports primitive types.
* Also updates `go.mod` to `1.19`.

Thanks to @peterhellberg for being helpful on Go Slack! Find his demo: https://go.dev/play/p/bAwvt92thoS

/cc @AlekSi 